### PR TITLE
Set bodyParser limit

### DIFF
--- a/server.js
+++ b/server.js
@@ -11,12 +11,18 @@ app.set("view engine", "pug");
 
 const store = [];
 
+const maxRequestBodySize = process.env.PORT || "10mb";
 app.use(
   bodyParser.urlencoded({
-    extended: false
+    extended: false,
+    limit: maxRequestBodySize
   })
 );
-app.use(bodyParser.json());
+app.use(
+  bodyParser.json({
+    limit: maxRequestBodySize
+  })
+);
 
 app.use(
   session({

--- a/server.js
+++ b/server.js
@@ -11,7 +11,7 @@ app.set("view engine", "pug");
 
 const store = [];
 
-const maxRequestBodySize = process.env.PORT || "10mb";
+const maxRequestBodySize = process.env.MAX_BODY_SIZE || "10mb";
 app.use(
   bodyParser.urlencoded({
     extended: false,


### PR DESCRIPTION
requestの最大body sizeを環境変数で設定できるようにした。
未設定の場合は`10mb`となる。
expressjsのdefaultである`100kb`は添付ファイルが含まれる際に容易に超過してしてしまうため。

https://github.com/expressjs/body-parser#limit