### PR TITLE
fix: use personalizations[x].subject when truthy

### DIFF
--- a/server.js
+++ b/server.js
@@ -76,6 +76,7 @@ app.post("/v3/mail/send", function (req, res) {
     ({ substitutions = { }, ...personalization }) => {
       return {
         ...message,
+        subject: personalization.subject || message.subject,
         content: content.map(c => {
           if (!c.value) return c;
           return {

--- a/views/index.pug
+++ b/views/index.pug
@@ -39,10 +39,10 @@ html
             .card(onclick=`setData(${JSON.stringify(mail)}, ${index})`)
               .card-content
                 .msg-header= `${mail.from.name ? `${mail.from.name}(${mail.from.email})` : mail.from.email} → ${mail.personalizations[0].to[0].name ? `${mail.personalizations[0].to[0].name} (${mail.personalizations[0].to[0].email})` : mail.personalizations[0].to[0].email}`
-                .msg-subject= mail.subject
+                .msg-subject= mail.personalizations[0].subject || mail.subject
                 .msg-sent-at= new Date(mail.sent_at).toISOString().slice(0, -8)
       .column.is-7.messages.is-fullheight
-        #js-message-title.subtitle.message-title 
+        #js-message-title.subtitle.message-title
         #js-message-attachments.attachments
         #js-message-content.message-content
       script.
@@ -52,7 +52,7 @@ html
           var title = document.getElementById("js-message-title");
           var attachments =  document.getElementById("js-message-attachments");
           var messageContent = document.getElementById("js-message-content");
-          title.innerHTML = `<span>${mail.subject}</span>`
+          title.innerHTML = `<span>${mail.personalizations[0].subject || mail.subject}</span>`
           var content = mail.content[0]
           if (content.type === "text/html") {
             messageContent.innerHTML = content.value;
@@ -64,7 +64,7 @@ html
           attachments.innerHTML = mail.attachments.map(attachment => (
             `<a download="${attachment.filename}" href="data:${attachment.type};base64,${attachment.content}" class="button is-small">${attachment.filename}</a>`
           )).join('')
-          var cards = document.getElementsByClassName("card") 
+          var cards = document.getElementsByClassName("card")
           cards[index].classList.add("active")
           if (before !== -1) {
             cards[before].classList.remove("active")

--- a/views/index.pug
+++ b/views/index.pug
@@ -39,10 +39,10 @@ html
             .card(onclick=`setData(${JSON.stringify(mail)}, ${index})`)
               .card-content
                 .msg-header= `${mail.from.name ? `${mail.from.name}(${mail.from.email})` : mail.from.email} → ${mail.personalizations[0].to[0].name ? `${mail.personalizations[0].to[0].name} (${mail.personalizations[0].to[0].email})` : mail.personalizations[0].to[0].email}`
-                .msg-subject= mail.personalizations[0].subject || mail.subject
+                .msg-subject= mail.subject
                 .msg-sent-at= new Date(mail.sent_at).toISOString().slice(0, -8)
       .column.is-7.messages.is-fullheight
-        #js-message-title.subtitle.message-title
+        #js-message-title.subtitle.message-title 
         #js-message-attachments.attachments
         #js-message-content.message-content
       script.
@@ -52,7 +52,7 @@ html
           var title = document.getElementById("js-message-title");
           var attachments =  document.getElementById("js-message-attachments");
           var messageContent = document.getElementById("js-message-content");
-          title.innerHTML = `<span>${mail.personalizations[0].subject || mail.subject}</span>`
+          title.innerHTML = `<span>${mail.subject}</span>`
           var content = mail.content[0]
           if (content.type === "text/html") {
             messageContent.innerHTML = content.value;
@@ -64,7 +64,7 @@ html
           attachments.innerHTML = mail.attachments.map(attachment => (
             `<a download="${attachment.filename}" href="data:${attachment.type};base64,${attachment.content}" class="button is-small">${attachment.filename}</a>`
           )).join('')
-          var cards = document.getElementsByClassName("card")
+          var cards = document.getElementsByClassName("card") 
           cards[index].classList.add("active")
           if (before !== -1) {
             cards[before].classList.remove("active")


### PR DESCRIPTION
## Description
This pull request modifies the behavior of the mail display logic to prioritize displaying `mail.personalizations[0].subject` over `mail.subject` when `mail.personalizations[0].subject` is truthy. This change aligns our implementation more closely with the documented behavior of the SendGrid API.

## Background
According to the SendGrid API schema, the subject of an email can be overridden by `personalizations[x].subject`. Currently, our application does not consider `personalizations[x].subject` and only displays `mail.subject`. This oversight leads to inconsistencies between the expected and actual behavior when utilizing SendGrid's API.

The documentation explicitly states about subject.
>  This may be overridden by subject lines set in personalizations.

For reference, please see the SendGrid documentation:
https://docs.sendgrid.com/api-reference/mail-send/mail-send#body

## Changes
The following changes have been implemented:

Added logic to check if `mail.personalizations[0].subject` contains a truthy value.
If truthy, `mail.personalizations[0].subject` is displayed in both the email list and the detailed view.
This ensures consistency with SendGrid's intended functionality.

## Impact
This update will lead to a more accurate representation of email subjects as intended by email senders using personalized subjects through SendGrid. It also enhances the user's ability to see the most relevant subject information at a glance.